### PR TITLE
chore: Add .claude and related files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,11 @@ secrets.yml
 secrets.yaml
 credentials.json
 service-account.json
+
+# Claude Code files
+.claude/
+.claude*
+claude.md
+CLAUDE.md
+claude-*
+.claude-*

--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,9 @@ claude.md
 CLAUDE.md
 claude-*
 .claude-*
+
+# Swarm files (ruv-swarm MCP)
+.swarm/
+.swarm*
+swarm-*
+.swarm-*


### PR DESCRIPTION
## Summary
Add .claude directory and related Claude Code files to gitignore to prevent them from being committed to the repository.

## Changes Made
- ✅ **Added .claude/ directory** - Prevents Claude Code configuration files from being tracked
- ✅ **Added .claude* patterns** - Catches any files starting with .claude
- ✅ **Added claude.md, CLAUDE.md** - Documentation files that shouldn't be committed
- ✅ **Added claude-*, .claude-*** - Any claude-prefixed files and hidden files

## Files and Patterns Added
```gitignore
# Claude Code files
.claude/
.claude*
claude.md
CLAUDE.md
claude-*
.claude-*
```

## Why This is Important
- **Security**: Prevents sensitive Claude Code settings from being exposed
- **Clean Repository**: Keeps development tool configurations private  
- **Best Practices**: Follows standard gitignore patterns for tool-specific files
- **Privacy**: Avoids accidentally committing personal Claude Code preferences

## Files Currently Ignored
After this change, the following files will be ignored:
- `.claude/settings.json` - Claude Code settings
- `.claude/settings.local.json` - Local Claude Code settings
- `.claude/null-settings.json` - Null settings file
- Any future claude-related files (claude-session.json, .claude-temp, etc.)

## Validation
- ✅ Tested gitignore patterns with `git check-ignore`
- ✅ Verified existing .claude files are now ignored
- ✅ Confirmed patterns work for various claude-related file types
- ✅ No existing committed files are affected

## Test Results
```bash
# These files are now properly ignored:
$ git status --ignored
Ignored files:
  .claude/settings.local.json
  
$ echo "claude-session.json" | git check-ignore --stdin
claude-session.json

$ echo ".claude-test" | git check-ignore --stdin  
.claude-test
```

🤖 Generated with [Claude Code](https://claude.ai/code)