### PR TITLE
Fix unpinned GitHub Actions in workflows

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -179,27 +179,7 @@ jobs:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
-          # 2025 Enhancement: Enable all checks
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          checks: >-
-            Binary-Artifacts,
-            Branch-Protection,
-            CII-Best-Practices,
-            CI-Tests,
-            Code-Review,
-            Contributors,
-            Dangerous-Workflow,
-            Dependency-Update-Tool,
-            Dependencies,
-            Fuzzing,
-            License,
-            Maintained,
-            Packaging,
-            SAST,
-            Security-Policy,
-            Signed-Releases,
-            Token-Permissions,
-            Vulnerabilities
 
       - name: Upload OSSF Scorecard results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v4.31.2


### PR DESCRIPTION
Remove 'checks' parameter from ossf/scorecard-action@v2.4.3 as it is not a valid input for this version. The action will run all available checks by default.

Valid inputs for this version are:
- entryPoint, args, results_file, results_format, repo_token, publish_results, file_mode, internal_publish_base_url, internal_default_token